### PR TITLE
feat: Implement UC13 grocery list feature: Show customers per bought product

### DIFF
--- a/Grocery.App/Converters/InverseBoolConverter.cs
+++ b/Grocery.App/Converters/InverseBoolConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace Grocery.App.Converters
+{
+    public class InverseBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !(bool)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !(bool)value;
+        }
+    }
+}

--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -4,15 +4,16 @@ using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
 using System.Collections.ObjectModel;
 
-
 namespace Grocery.App.ViewModels
 {
     public partial class BoughtProductsViewModel : BaseViewModel
     {
         private readonly IBoughtProductsService _boughtProductsService;
 
-        [ObservableProperty]
-        Product? selectedProduct;
+        [ObservableProperty] Product? selectedProduct;
+
+        public bool IsProductSelected => SelectedProduct != null;
+
         public ObservableCollection<BoughtProducts> BoughtProductsList { get; set; } = [];
         public ObservableCollection<Product> Products { get; set; }
 
@@ -20,19 +21,24 @@ namespace Grocery.App.ViewModels
         {
             _boughtProductsService = boughtProductsService;
             Products = new(productService.GetAll());
-            // Initially load all bought products
-            LoadBoughtProducts(null);
         }
 
         partial void OnSelectedProductChanged(Product? newValue)
         {
-            // The newValue can be null if the picker selection is cleared.
             LoadBoughtProducts(newValue?.Id);
+            OnPropertyChanged(nameof(IsProductSelected));
         }
 
         private void LoadBoughtProducts(int? productId)
         {
             BoughtProductsList.Clear();
+
+            if (productId == null)
+            {
+                // No product selected
+                return;
+            }
+
             var productsToLoad = _boughtProductsService.Get(productId);
             foreach (var item in productsToLoad)
             {

--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -12,7 +12,7 @@ namespace Grocery.App.ViewModels
         private readonly IBoughtProductsService _boughtProductsService;
 
         [ObservableProperty]
-        Product selectedProduct;
+        Product? selectedProduct;
         public ObservableCollection<BoughtProducts> BoughtProductsList { get; set; } = [];
         public ObservableCollection<Product> Products { get; set; }
 
@@ -20,11 +20,24 @@ namespace Grocery.App.ViewModels
         {
             _boughtProductsService = boughtProductsService;
             Products = new(productService.GetAll());
+            // Initially load all bought products
+            LoadBoughtProducts(null);
         }
 
-        partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
+        partial void OnSelectedProductChanged(Product? newValue)
         {
-            //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
+            // The newValue can be null if the picker selection is cleared.
+            LoadBoughtProducts(newValue?.Id);
+        }
+
+        private void LoadBoughtProducts(int? productId)
+        {
+            BoughtProductsList.Clear();
+            var productsToLoad = _boughtProductsService.Get(productId);
+            foreach (var item in productsToLoad)
+            {
+                BoughtProductsList.Add(item);
+            }
         }
 
         [RelayCommand]

--- a/Grocery.App/ViewModels/GroceryListViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListViewModel.cs
@@ -10,11 +10,15 @@ namespace Grocery.App.ViewModels
     {
         public ObservableCollection<GroceryList> GroceryLists { get; set; }
         private readonly IGroceryListService _groceryListService;
+        private readonly GlobalViewModel _global;
+        public GlobalViewModel Global => _global;
+        
 
-        public GroceryListViewModel(IGroceryListService groceryListService) 
+        public GroceryListViewModel(IGroceryListService groceryListService, GlobalViewModel global)
         {
             Title = "Boodschappenlijst";
             _groceryListService = groceryListService;
+            _global = global;
             GroceryLists = new(_groceryListService.GetAll());
         }
 
@@ -22,8 +26,22 @@ namespace Grocery.App.ViewModels
         public async Task SelectGroceryList(GroceryList groceryList)
         {
             Dictionary<string, object> paramater = new() { { nameof(GroceryList), groceryList } };
-            await Shell.Current.GoToAsync($"{nameof(Views.GroceryListItemsView)}?Titel={groceryList.Name}", true, paramater);
+            await Shell.Current.GoToAsync($"{nameof(Views.GroceryListItemsView)}?Titel={groceryList.Name}", true,
+                paramater);
         }
+
+        [RelayCommand]
+        public async Task ShowBoughtProducts()
+        {
+            // Check if the Client has the Admin role using Global
+            if (_global.Client?.Role == Role.Admin)
+            {
+                // Navigate to BoughtProductsView
+                await Shell.Current.GoToAsync($"{nameof(Views.BoughtProductsView)}", true);
+            }
+            // Do nothing if Client is not an Admin
+        }
+
         public override void OnAppearing()
         {
             base.OnAppearing();

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -34,7 +34,8 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <!-- Toon hier de naam van de Client naam van de boodschappenlijst -->
+                            <Label Text="{Binding Client.Name}" Grid.Column="0" />
+                            <Label Text="{Binding GroceryList.Name}" Grid.Column="1" />
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
+
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
@@ -8,31 +9,34 @@
              Title="BoughtProductsView">
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="4*"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="4*" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition Height="80"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="80" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title="Klik op onderstaand pijltje om een product te selecteren:"
-        ItemsSource="{Binding Products}"
-        SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
-        SelectedIndexChanged="Picker_SelectedIndexChanged"
-        BackgroundColor="{StaticResource Primary}"
-            TextColor="{StaticResource Secondary}">
+        <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title=""
+                ItemsSource="{Binding Products}"
+                ItemDisplayBinding="{Binding Name}"
+                SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
+                SelectedIndexChanged="Picker_SelectedIndexChanged"
+                BackgroundColor="{StaticResource Primary}"
+                TextColor="{StaticResource Secondary}">
         </Picker>
-        <Border Grid.Row="1" Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
-            <CollectionView ItemsSource="{Binding BoughtProductsList}" Margin="5" HorizontalOptions="End" SelectionMode="Single">
+        <Border Grid.Row="1" Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5"
+                HorizontalOptions="Center">
+            <CollectionView ItemsSource="{Binding BoughtProductsList}" Margin="5" HorizontalOptions="End"
+                            SelectionMode="Single">
                 <CollectionView.ItemsLayout>
                     <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="m:BoughtProducts" >
+                    <DataTemplate x:DataType="m:BoughtProducts">
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <Label Text="{Binding Client.Name}" Grid.Column="0" />
                             <Label Text="{Binding GroceryList.Name}" Grid.Column="1" />
@@ -41,7 +45,8 @@
                 </CollectionView.ItemTemplate>
                 <CollectionView.EmptyView>
                     <ContentView>
-                        <Label Text="Er zijn geen verkochte producten" FontSize="18" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
+                        <Label Text="Er zijn geen verkochte producten" FontSize="18" FontAttributes="Bold"
+                               HorizontalTextAlignment="Center" />
                     </ContentView>
                 </CollectionView.EmptyView>
             </CollectionView>

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -4,52 +4,91 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              xmlns:m="clr-namespace:Grocery.Core.Models;assembly=Grocery.Core"
+             xmlns:converters="clr-namespace:Grocery.App.Converters"
              x:Class="Grocery.App.Views.BoughtProductsView"
              x:DataType="vm:BoughtProductsViewModel"
              Title="BoughtProductsView">
+
+    <ContentPage.Resources>
+        <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
+    </ContentPage.Resources>
+
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="4*" />
+            <ColumnDefinition Width="15*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="80" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title=""
-                ItemsSource="{Binding Products}"
-                ItemDisplayBinding="{Binding Name}"
-                SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
-                SelectedIndexChanged="Picker_SelectedIndexChanged"
-                BackgroundColor="{StaticResource Primary}"
-                TextColor="{StaticResource Secondary}">
-        </Picker>
+
+        <Grid Grid.Column="0" Grid.Row="0" Margin="10,0,0,0">
+            <Picker Title=""
+                    ItemsSource="{Binding Products}"
+                    ItemDisplayBinding="{Binding Name}"
+                    SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
+                    SelectedIndexChanged="Picker_SelectedIndexChanged"
+                    BackgroundColor="{StaticResource Primary}"
+                    TextColor="{StaticResource Secondary}">
+            </Picker>
+
+            <Label Text="Selecteer een product"
+                   VerticalOptions="Center"
+                   Margin="15,0,0,0"
+                   TextColor="LightGray"
+                   IsVisible="{Binding IsProductSelected, Converter={StaticResource InverseBoolConverter}}" />
+        </Grid>
+
+
         <Border Grid.Row="1" Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5"
                 HorizontalOptions="Center">
-            <CollectionView ItemsSource="{Binding BoughtProductsList}" Margin="5" HorizontalOptions="End"
-                            SelectionMode="Single">
-                <CollectionView.ItemsLayout>
-                    <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
-                </CollectionView.ItemsLayout>
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="m:BoughtProducts">
-                        <Grid>
+            <Grid>
+                <CollectionView ItemsSource="{Binding BoughtProductsList}" Margin="5" HorizontalOptions="End"
+                                SelectionMode="Single" IsVisible="{Binding IsProductSelected}">
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.Header>
+                        <Grid Padding="0,0,0,5">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Label Text="{Binding Client.Name}" Grid.Column="0" />
-                            <Label Text="{Binding GroceryList.Name}" Grid.Column="1" />
+                            <Label Text="Klant" Grid.Column="0" FontAttributes="Bold" HorizontalOptions="Start"
+                                   Margin="10,0,0,0" />
+                            <Label Text="Boodschappenlijst" Grid.Column="1" FontAttributes="Bold"
+                                   HorizontalOptions="Start" Margin="10,0,0,0" />
                         </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-                <CollectionView.EmptyView>
-                    <ContentView>
-                        <Label Text="Er zijn geen verkochte producten" FontSize="18" FontAttributes="Bold"
-                               HorizontalTextAlignment="Center" />
-                    </ContentView>
-                </CollectionView.EmptyView>
-            </CollectionView>
+                    </CollectionView.Header>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="m:BoughtProducts">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Label Text="{Binding Client.Name}" Grid.Column="0" HorizontalOptions="Start"
+                                       Margin="10,0,0,0" />
+                                <Label Text="{Binding GroceryList.Name}" Grid.Column="1" HorizontalOptions="Start" />
+                            </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                    <CollectionView.EmptyView>
+                        <ContentView>
+                            <Label Text="Er zijn geen verkochte producten" FontSize="18" FontAttributes="Bold"
+                                   HorizontalTextAlignment="Center" />
+                        </ContentView>
+                    </CollectionView.EmptyView>
+                </CollectionView>
+
+                <Label Text="Selecteer eerst een product"
+                       FontSize="18"
+                       FontAttributes="Bold"
+                       HorizontalTextAlignment="Center"
+                       VerticalOptions="Center"
+                       IsVisible="{Binding IsProductSelected, Converter={StaticResource InverseBoolConverter}}" />
+            </Grid>
         </Border>
     </Grid>
 </ContentPage>

--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
+
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Grocery.App.Views.GroceryListsView"
@@ -12,11 +13,17 @@
         </Grid>
     </Shell.TitleView>
 
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{Binding Global.Client.Name}"
+                     Command="{Binding ShowBoughtProductsCommand}" />
+    </ContentPage.ToolbarItems>
+
+
     <Border Stroke="#C49B33"
-        StrokeThickness="4"
-        Padding="10"
-        Margin="10"
-        HorizontalOptions="Center">
+            StrokeThickness="4"
+            Padding="10"
+            Margin="10"
+            HorizontalOptions="Center">
         <CollectionView x:Name="GroceryListView" ItemsSource="{Binding GroceryLists}" HorizontalOptions="Center"
                         SelectionMode="Single"
                         SelectionChangedCommand="{Binding SelectGroceryListCommand}"
@@ -29,13 +36,14 @@
                 <DataTemplate x:DataType="m:GroceryList">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="2*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="15"/>
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="15" />
                         </Grid.ColumnDefinitions>
-                        <Label Grid.Column="0" Text="{Binding Name}"/>
-                        <Label Grid.Column="1" Text="{Binding Date}" HorizontalOptions="End" Margin="0,0,10,0"/>
-                        <Rectangle Grid.Column="2" BackgroundColor="{Binding Color}" WidthRequest="15" HeightRequest="15" />
+                        <Label Grid.Column="0" Text="{Binding Name}" />
+                        <Label Grid.Column="1" Text="{Binding Date}" HorizontalOptions="End" Margin="0,0,10,0" />
+                        <Rectangle Grid.Column="2" BackgroundColor="{Binding Color}" WidthRequest="15"
+                                   HeightRequest="15" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -1,5 +1,4 @@
-﻿
-using Grocery.Core.Interfaces.Repositories;
+﻿using Grocery.Core.Interfaces.Repositories;
 using Grocery.Core.Models;
 
 namespace Grocery.Core.Data.Repositories
@@ -13,7 +12,7 @@ namespace Grocery.Core.Data.Repositories
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
                 new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
-                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=")
+                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=", Role.Admin)
             ];
         }
 

--- a/Grocery.Core/Interfaces/Services/IClientService.cs
+++ b/Grocery.Core/Interfaces/Services/IClientService.cs
@@ -1,13 +1,11 @@
 ﻿using Grocery.Core.Models;
 
-namespace Grocery.Core.Interfaces.Services
+public interface IClientService
 {
-    public interface IClientService
-    {
-        public Client? Get(string email);
-
-        public Client? Get(int id);
-
-        public List<Client> GetAll();
-    }
+    Client? Get(string email);
+    Client? Get(int id);
+    List<Client> GetAll();
+    Client? GetCurrentClient();
+    void SetCurrentClient(Client client);
+    void ClearCurrentClient();
 }

--- a/Grocery.Core/Interfaces/Services/IClientService.cs
+++ b/Grocery.Core/Interfaces/Services/IClientService.cs
@@ -5,7 +5,5 @@ public interface IClientService
     Client? Get(string email);
     Client? Get(int id);
     List<Client> GetAll();
-    Client? GetCurrentClient();
-    void SetCurrentClient(Client client);
-    void ClearCurrentClient();
+
 }

--- a/Grocery.Core/Models/Client.cs
+++ b/Grocery.Core/Models/Client.cs
@@ -1,14 +1,17 @@
-﻿
-namespace Grocery.Core.Models
+﻿namespace Grocery.Core.Models
 {
     public partial class Client : Model
     {
         public string EmailAddress { get; set; }
         public string Password { get; set; }
-        public Client(int id, string name, string emailAddress, string password) : base(id, name)
+
+        public Role Role { get; set; } 
+        
+        public Client(int id, string name, string emailAddress, string password, Role role=Role.None) : base(id, name)
         {
             EmailAddress=emailAddress;
             Password=password;
+            Role=role;
         }
     }
 }

--- a/Grocery.Core/Models/Role.cs
+++ b/Grocery.Core/Models/Role.cs
@@ -1,0 +1,8 @@
+namespace Grocery.Core.Models
+{
+    public enum Role
+    {
+        None,
+        Admin
+    }
+}

--- a/Grocery.Core/Services/BoughtProductsService.cs
+++ b/Grocery.Core/Services/BoughtProductsService.cs
@@ -1,5 +1,4 @@
-﻿
-using Grocery.Core.Interfaces.Repositories;
+﻿using Grocery.Core.Interfaces.Repositories;
 using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
 
@@ -11,16 +10,39 @@ namespace Grocery.Core.Services
         private readonly IClientRepository _clientRepository;
         private readonly IProductRepository _productRepository;
         private readonly IGroceryListRepository _groceryListRepository;
-        public BoughtProductsService(IGroceryListItemsRepository groceryListItemsRepository, IGroceryListRepository groceryListRepository, IClientRepository clientRepository, IProductRepository productRepository)
+
+        public BoughtProductsService(IGroceryListItemsRepository groceryListItemsRepository,
+            IGroceryListRepository groceryListRepository, IClientRepository clientRepository,
+            IProductRepository productRepository)
         {
-            _groceryListItemsRepository=groceryListItemsRepository;
-            _groceryListRepository=groceryListRepository;
-            _clientRepository=clientRepository;
-            _productRepository=productRepository;
+            _groceryListItemsRepository = groceryListItemsRepository;
+            _groceryListRepository = groceryListRepository;
+            _clientRepository = clientRepository;
+            _productRepository = productRepository;
         }
+
         public List<BoughtProducts> Get(int? productId)
         {
-            throw new NotImplementedException();
+            var boughtProducts = _groceryListRepository.GetAll()
+                .Join(_clientRepository.GetAll(),
+                    gl => gl.ClientId,
+                    c => c.Id,
+                    (gl, c) => new { GroceryList = gl, Client = c })
+                .Join(_groceryListItemsRepository.GetAll(),
+                    temp => temp.GroceryList.Id,
+                    gli => gli.GroceryListId,
+                    (temp, gli) => new { temp.GroceryList, temp.Client, GroceryListItem = gli })
+                .Where(temp => productId == null || temp.GroceryListItem.ProductId == productId)
+                .Join(_productRepository.GetAll(),
+                    temp => temp.GroceryListItem.ProductId,
+                    p => p.Id,
+                    (temp, p) => new BoughtProducts(
+                        temp.Client,
+                        temp.GroceryList,
+                        p))
+                .ToList();
+
+            return boughtProducts;
         }
     }
 }

--- a/Grocery.Core/Services/ClientService.cs
+++ b/Grocery.Core/Services/ClientService.cs
@@ -33,18 +33,5 @@ namespace Grocery.Core.Services
             List<Client> clients = _clientRepository.GetAll();
             return clients;
         }
-        public Client? GetCurrentClient()
-        {
-            return _currentClient;
-        }
-        public void SetCurrentClient(Client client)
-        {
-            _currentClient = client;
-        }
-
-        public void ClearCurrentClient()
-        {
-            _currentClient = null;
-        }
     }
 }

--- a/Grocery.Core/Services/ClientService.cs
+++ b/Grocery.Core/Services/ClientService.cs
@@ -12,6 +12,7 @@ namespace Grocery.Core.Services
     public class ClientService : IClientService
     {
         private readonly IClientRepository _clientRepository;
+        private static Client? _currentClient;
         public ClientService(IClientRepository clientRepository)
         {
             _clientRepository = clientRepository;
@@ -31,6 +32,19 @@ namespace Grocery.Core.Services
         {
             List<Client> clients = _clientRepository.GetAll();
             return clients;
+        }
+        public Client? GetCurrentClient()
+        {
+            return _currentClient;
+        }
+        public void SetCurrentClient(Client client)
+        {
+            _currentClient = client;
+        }
+
+        public void ClearCurrentClient()
+        {
+            _currentClient = null;
         }
     }
 }


### PR DESCRIPTION
This pull request introduces role-based access control for admin features, improves the user experience in the Bought Products view, and refactors several parts of the codebase to support these changes. The most significant updates are the introduction of an `Admin` role to the `Client` model, the addition of UI logic to restrict access to admin-only features, and enhancements to the Bought Products selection and display workflow.

**Role-based access and model updates:**

* Added a `Role` enum (`Role.None`, `Role.Admin`) and updated the `Client` model to include a `Role` property. The constructor now accepts a role, defaulting to `None`. [[1]](diffhunk://#diff-07aaf804dd7ec9ca6c11436b3484fac046b8997c8c9c526c5a0c0059d2d64715L1-R14) [[2]](diffhunk://#diff-67b9b4cbd7eac792de4d3ffd95184024f7366a1541e8e481e676e93258e7a70aR1-R8)
* Updated `ClientRepository` to assign the `Admin` role to a specific client for demonstration/testing purposes.

**Bought Products view and logic improvements:**

* Refactored `BoughtProductsViewModel` to use a nullable `SelectedProduct`, added an `IsProductSelected` property, and updated the product selection logic to load bought products and notify the UI. [[1]](diffhunk://#diff-fc4fbe4ed2ea168afb6b59d91d8c7417d91038a78bcc77efb83bbb0832524955L7-R16) [[2]](diffhunk://#diff-fc4fbe4ed2ea168afb6b59d91d8c7417d91038a78bcc77efb83bbb0832524955L25-R46)
* Enhanced the `BoughtProductsView.xaml` UI: added an `InverseBoolConverter` to show/hide elements based on whether a product is selected, improved layout, and added headers to the product list. [[1]](diffhunk://#diff-873738d887b66c76e14e1752865b5a32bf508caf2b336bfd9c81bb596da81866R2-R91) [[2]](diffhunk://#diff-594e290900e44379b4492128ffadf1d714ac121d3f7851010c970a433eadc49cR1-R19)

**Navigation and admin-only command:**

* Added a `ShowBoughtProducts` command to `GroceryListViewModel` that navigates to the Bought Products view only if the current client is an admin. Exposed the global client for binding.
* Added a toolbar item in `GroceryListsView.xaml` to trigger the admin-only command, displaying the current client's name.

**Service and repository enhancements:**

* Implemented the `Get` method in `BoughtProductsService` to retrieve bought products for a selected product, including client and grocery list details.
* Cleaned up and clarified interfaces in `IClientService`.

These changes collectively enable admin users to access and view bought products, and improve the UI.