### PR TITLE
hotfix: UC10 quantity buttons fixed

### DIFF
--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
+
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:m="clr-namespace:Grocery.Core.Models;assembly=Grocery.Core"
@@ -8,23 +9,28 @@
              Title="GroceryListItemsView">
 
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="Wijzig kleur" Command="{Binding ChangeColorCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
-        <ToolbarItem Text="Deel boodschappenlijst" Command="{Binding ShareGroceryListCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
+        <ToolbarItem Text="Wijzig kleur" Command="{Binding ChangeColorCommand}"
+                     IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
+        <ToolbarItem Text="Deel boodschappenlijst" Command="{Binding ShareGroceryListCommand}"
+                     IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
     </ContentPage.ToolbarItems>
-    
+
     <Shell.TitleView>
         <Grid>
-            <Label Text="{Binding GroceryList.Name}" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
+            <Label Text="{Binding GroceryList.Name}" FontSize="Large" HorizontalOptions="Center"
+                   VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="4*"/>
-            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="4*" />
+            <ColumnDefinition Width="2*" />
         </Grid.ColumnDefinitions>
-        <Border Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="10" Margin="10" HorizontalOptions="Center">
-            <CollectionView ItemsSource="{Binding MyGroceryListItems}" Margin="20" HorizontalOptions="Center" EmptyView="De boodschappenlijst is nog leeg. Voeg eerst boodschappen toe!">
+        <Border Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="10" Margin="10"
+                HorizontalOptions="Center">
+            <CollectionView ItemsSource="{Binding MyGroceryListItems}" Margin="20" HorizontalOptions="Center"
+                            EmptyView="De boodschappenlijst is nog leeg. Voeg eerst boodschappen toe!">
                 <CollectionView.ItemsLayout>
                     <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
                 </CollectionView.ItemsLayout>
@@ -33,18 +39,31 @@
                     <DataTemplate x:DataType="m:GroceryListItem">
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="4*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="20"/>
-                                <ColumnDefinition Width="20"/>
+                                <ColumnDefinition Width="4*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="20" />
+                                <ColumnDefinition Width="20" />
                             </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
-                            <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
+                            <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center" />
+                            <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center"
+                                   HorizontalOptions="End" Margin="0,0,10,0" />
                             <Grid Grid.Column="2">
-                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15"/>
+                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15">
+                                    <Image.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:GroceryListItemsViewModel}}, Path=IncreaseAmountCommand}"
+                                            CommandParameter="{Binding ProductId}" />
+                                    </Image.GestureRecognizers>
+                                </Image>
                             </Grid>
                             <Grid Grid.Column="3">
-                                <Image Source="min.png" WidthRequest="15" HeightRequest="15"/>
+                                <Image Source="min.png" WidthRequest="15" HeightRequest="15">
+                                    <Image.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:GroceryListItemsViewModel}}, Path=DecreaseAmountCommand}"
+                                            CommandParameter="{Binding ProductId}" />
+                                    </Image.GestureRecognizers>
+                                </Image>
                             </Grid>
                         </Grid>
                     </DataTemplate>
@@ -52,13 +71,16 @@
             </CollectionView>
         </Border>
 
-        <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
+        <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5"
+                HorizontalOptions="Center">
             <StackLayout>
-                <SearchBar x:Name="searchBar" SearchCommand="{Binding PerformSearchCommand}" SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}}"/>
-                <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
-            SelectionMode="Single"
-            SelectionChangedCommand="{Binding AddProductCommand}"
-            SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
+                <SearchBar x:Name="searchBar" SearchCommand="{Binding PerformSearchCommand}"
+                           SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}}" />
+                <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300"
+                                HorizontalOptions="Start"
+                                SelectionMode="Single"
+                                SelectionChangedCommand="{Binding AddProductCommand}"
+                                SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
                     <CollectionView.ItemsLayout>
                         <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
                     </CollectionView.ItemsLayout>
@@ -66,24 +88,27 @@
                         <DataTemplate x:DataType="m:Product">
                             <Grid>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="3*"/>
-                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Label Grid.Column="0" Text="{Binding Name}" VerticalOptions="Center"/>
-                                <Label Grid.Column="1" Text="{Binding Stock}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
+                                <Label Grid.Column="0" Text="{Binding Name}" VerticalOptions="Center" />
+                                <Label Grid.Column="1" Text="{Binding Stock}" VerticalOptions="Center"
+                                       HorizontalOptions="End" Margin="0,0,10,0" />
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                     <CollectionView.EmptyView>
                         <ContentView>
                             <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
-                                <Label Text="Er zijn geen producten meer om toe te voegen" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
+                                <Label Text="Er zijn geen producten meer om toe te voegen" FontAttributes="Bold"
+                                       HorizontalTextAlignment="Center" />
                             </VerticalStackLayout>
                         </ContentView>
                     </CollectionView.EmptyView>
                 </CollectionView>
             </StackLayout>
         </Border>
-        <Label Grid.Row="0" Grid.Column="0" HorizontalOptions="Center" x:Name="Message" Text="{Binding MyMessage}" TextColor="Red" Margin="30,0,0,10"/>
+        <Label Grid.Row="0" Grid.Column="0" HorizontalOptions="Center" x:Name="Message" Text="{Binding MyMessage}"
+               TextColor="Red" Margin="30,0,0,10" />
     </Grid>
 </ContentPage>

--- a/Grocery.Core.Data/Grocery.Core.Data.csproj
+++ b/Grocery.Core.Data/Grocery.Core.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net8.0-maccatalyst</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Grocery.Core.Data/Repositories/GroceryListItemsRepository.cs
+++ b/Grocery.Core.Data/Repositories/GroceryListItemsRepository.cs
@@ -38,7 +38,8 @@ namespace Grocery.Core.Data.Repositories
 
         public GroceryListItem? Delete(GroceryListItem item)
         {
-            throw new NotImplementedException();
+            groceryListItems.Remove(item);
+            return item;
         }
 
         public GroceryListItem? Get(int id)

--- a/Grocery.Core/Grocery.Core.csproj
+++ b/Grocery.Core/Grocery.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net8.0-maccatalyst</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Grocery.Core/Services/GroceryListItemsService.cs
+++ b/Grocery.Core/Services/GroceryListItemsService.cs
@@ -36,7 +36,7 @@ namespace Grocery.Core.Services
 
         public GroceryListItem? Delete(GroceryListItem item)
         {
-            throw new NotImplementedException();
+            return _groceriesRepository.Delete(item);
         }
 
         public GroceryListItem? Get(int id)


### PR DESCRIPTION
The ability to change the amount of grocery list items with the + and - buttons, was not working. This was due to the absence of command bindings, the "buttons" were simply static pngs in the xaml. Also had to implement the necessary backend delete functionality, which up until this point was throwing a NotImplementedException.

### Backend Functionality

* Implemented the `Delete` method in both `GroceryListItemsRepository` and `GroceryListItemsService`, enabling removal of grocery list items from the repository and service layers. [[1]](diffhunk://#diff-911e04c1c5c35c35164bd3b57c6989d6d7e120981b35a902b2dd01598e42e670L41-R42) [[2]](diffhunk://#diff-13839e726be5ed899132468d95d1bab8930d7ace1da7a8147e8322098271c226L39-R39)

### UI/UX 

* Enhanced the `GroceryListItemsView.xaml` UI:
  - Added tap gesture recognizers to the plus/minus icons for increasing/decreasing item amounts, binding them to the appropriate commands in the view model.
  - Improved XAML formatting for readability and maintainability.
  - Added or adjusted bindings and UI elements for better user interaction and feedback. [[1]](diffhunk://#diff-61d5d43038bf4b4a77d20fc3f19df6615feb091c7bc43fac83a617793dc349b4L11-R21) [[2]](diffhunk://#diff-61d5d43038bf4b4a77d20fc3f19df6615feb091c7bc43fac83a617793dc349b4L26-R33) [[3]](diffhunk://#diff-61d5d43038bf4b4a77d20fc3f19df6615feb091c7bc43fac83a617793dc349b4L42-R80) [[4]](diffhunk://#diff-61d5d43038bf4b4a77d20fc3f19df6615feb091c7bc43fac83a617793dc349b4L73-R112)